### PR TITLE
Revised toggle for the namespace header omission

### DIFF
--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -22,13 +22,9 @@ const config = require('@adobe/aio-lib-core-config')
 let cli
 
 class RuntimeBaseCommand extends Command {
-  // Allows some toggling of behavior concerning the namespace header
-  // This allows avoidance of some CORS issues when code executes in a browser
-  omitWildcardNamespaceHeader = false
   setNamespaceHeaderOmission(newValue) {
-    this.omitWildcardNamespaceHeader = newValue
-  }
-
+    RuntimeBaseCommand.omitWildcardNamespaceHeader = newValue
+  }  
   async getOptions () {
     const { flags } = this.parse(this.constructor)
     let properties = { get: () => null }
@@ -48,7 +44,7 @@ class RuntimeBaseCommand extends Command {
     }
 
     // Optionally suppress sending of namespace header when namespace is nullified
-    if (this.omitWildcardNamespaceHeader && options.namespace === '_') {
+    if (RuntimeBaseCommand.omitWildcardNamespaceHeader && options.namespace === '_') {
       delete options.namespace
     }
 
@@ -190,5 +186,7 @@ RuntimeBaseCommand.flags = {
     default: 'aio-cli-plugin-runtime@' + require('../package.json').version
   })
 }
+
+RuntimeBaseCommand.omitWildcardNamespaceHeader = false
 
 module.exports = RuntimeBaseCommand

--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -22,6 +22,13 @@ const config = require('@adobe/aio-lib-core-config')
 let cli
 
 class RuntimeBaseCommand extends Command {
+  // Allows some toggling of behavior concerning the namespace header
+  // This allows avoidance of some CORS issues when code executes in a browser
+  omitWildcardNamespaceHeader = false
+  setNamespaceHeaderOmission(newValue) {
+    this.omitWildcardNamespaceHeader = newValue
+  }
+
   async getOptions () {
     const { flags } = this.parse(this.constructor)
     let properties = { get: () => null }
@@ -41,7 +48,7 @@ class RuntimeBaseCommand extends Command {
     }
 
     // Optionally suppress sending of namespace header when namespace is nullified
-    if (RuntimeBaseCommand.omitWildcardNamespaceHeader && options.namespace === '_') {
+    if (this.omitWildcardNamespaceHeader && options.namespace === '_') {
       delete options.namespace
     }
 
@@ -183,7 +190,5 @@ RuntimeBaseCommand.flags = {
     default: 'aio-cli-plugin-runtime@' + require('../package.json').version
   })
 }
-
-RuntimeBaseCommand.omitWildcardNamespaceHeader = false
 
 module.exports = RuntimeBaseCommand


### PR DESCRIPTION
## Description

Amendment to the original toggle for sending or omitting a namespace header when the namespace is wildcard

## Related Issue

Issue #8

## Motivation and Context

The original toggle required a static variable in a abstract base class to be set from a very different context (nim or the workbench).   Because of the way dependencies are handled it is not obvious how to do this and I couldn't get it to work.  Calling a (non-static) method to do the toggling simplifies that greatly.

## How Has This Been Tested?

Tested as part of testing the incorporation into nim and the workbench.   Ran the usual regression tests and manually tested the behavior of `activation logs`.
