### PR TITLE
Ensure that activation logs waits for output to be processed.

### DIFF
--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -59,7 +59,7 @@ class ActivationLogs extends RuntimeBaseCommand {
         filterActions.push(flags.action)
       }
 
-      rtLib.printActionLogs({ ow: owOptions }, this.log, limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch)
+      await rtLib.printActionLogs({ ow: owOptions }, this.log, limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch)
     } else {
       const logger = this.log
       return ow.activations.logs(args.activationId).then((result) => {


### PR DESCRIPTION
The `printActionLogs` function is async (returns a promise).   But, when it is called in `logs.js` there was no `await` on the invocation.   This means that the promise returned by the calling method can settle without implying that called method has settled.

This won't matter much in a CLI but when the command is embedded in another context it can cause logic in that outer context to proceed on the assumption that the output has been produced, when it has not necessarily been produced yet.

I had thought that this accounted for some symptoms I was seeing in our workbench when this code is incorporated.  I don't regard that as proven because some of those symptoms remain even with this fix in place.  But, even if the fix isn't sufficient I think it may be necessary and certainly improves the "correctness."
