### PR TITLE
Refactor last activation banner logic.

### DIFF
--- a/src/commands/runtime/activation/banner.js
+++ b/src/commands/runtime/activation/banner.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const moment = require('moment')
+const chalk = require('chalk')
+
+class ActivationBanner {
+}
+
+ActivationBanner.statusToString = (status) => {
+  switch (status) {
+    case 0: return 'success'
+    case 1: return 'application error'
+    case 2: return 'developer error'
+    case 3: return 'system error'
+    default: return '??'
+  }
+}
+
+/**
+ * Creates an info banner for an activation.
+ *
+ * @param {Activation} activation metadata
+ * @param {Array<string>} activationLogs the logs of the activation (may selectively suppress banner if there are no log lines)
+ * @returns banner string or falsy if no banner is desired
+ */
+ActivationBanner.makeBanner = (activation, activationLogs) => {
+  const end = moment(activation.end).format('MM/DD HH:mm:ss')
+  return chalk.dim('=== ') + chalk.bold(
+    `${activation.activationId} ` +
+      `(${ActivationBanner.statusToString(activation.statusCode)}) ` +
+      `${end} ` +
+      `${activation.name}:${activation.version || ''}`)
+}
+
+module.exports = ActivationBanner

--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -15,6 +15,7 @@ const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const rtLib = require('@adobe/aio-lib-runtime')
 const printLogs = rtLib.utils.printLogs
 const ActivationListLimits = require('./list').limits
+const { makeBanner } = require('./banner')
 
 class ActivationLogs extends RuntimeBaseCommand {
   async run () {
@@ -58,6 +59,7 @@ class ActivationLogs extends RuntimeBaseCommand {
         filterActions.push(flags.action)
       }
 
+      this.log.makeBanner = makeBanner
       await rtLib.printActionLogs({ ow: owOptions }, this.log, limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch)
     } else {
       const logger = this.log

--- a/test/commands/runtime/activation/banner.test.js
+++ b/test/commands/runtime/activation/banner.test.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { statusToString } = require('../../../../src/commands/runtime/activation/banner.js')
+
+test('map status code to string', () => {
+  expect(statusToString(0)).toMatch('success')
+  expect(statusToString(1)).toMatch('application error')
+  expect(statusToString(2)).toMatch('developer error')
+  expect(statusToString(3)).toMatch('system error')
+  expect(statusToString(undefined)).toMatch('??')
+})

--- a/test/commands/runtime/activation/result.test.js
+++ b/test/commands/runtime/activation/result.test.js
@@ -120,13 +120,6 @@ describe('instance methods', () => {
         })
     })
 
-    test('map status code to string', () => {
-      expect(TheCommand.statusToString(0)).toMatch('success')
-      expect(TheCommand.statusToString(1)).toMatch('application error')
-      expect(TheCommand.statusToString(2)).toMatch('developer error')
-      expect(TheCommand.statusToString(3)).toMatch('system error')
-    })
-
     test('should not fail on get activation result w/ noflag, no activationId', () => {
       const axList = rtLib.mockResolved('activations.list', [])
       return command.run()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactors logic which emits intra activation banners when separating multiple activation results or logs.
This log is used with `activation get --last --result|--logs` and `activation result --last [--limit N]`. A `--quiet` flag will suppress the banner.

To use this banner logic with `activation logs`, a patch is needed in AIO https://github.com/adobe/aio-lib-runtime/issues/27.

## Related Issue

See #23.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
