### PR TITLE
Write out action env vars to a file in JSON.

### DIFF
--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 const fs = require('fs')
 const path = require('path')
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
-const { createKeyValueArrayFromFlag, createKeyValueArrayFromFile, createComponentsfromSequence, getKeyValueArrayFromMergedParameters } = require('@adobe/aio-lib-runtime').utils
+const { createComponentsfromSequence, getKeyValueArrayFromMergedParameters } = require('@adobe/aio-lib-runtime').utils
 const { kindForFileExtension } = require('../../../kinds')
 const { flags } = require('@oclif/command')
 
@@ -113,15 +113,11 @@ class ActionCreate extends RuntimeBaseCommand {
 
       paramsAction = getKeyValueArrayFromMergedParameters(flags.param, flags['param-file'])
 
-      if (flags.env) {
-        // each --env flag expects two values ( a key and a value ). Multiple --env flags can be passed
-        // For example : aio runtime:action:update --env name "foo" --env city "bar"
-        envParams = createKeyValueArrayFromFlag(flags.env)
-      } else if (flags['env-file']) {
-        envParams = createKeyValueArrayFromFile(flags['env-file'])
+      if (flags.env || flags['env-file']) {
+        envParams = getKeyValueArrayFromMergedParameters(flags.env, flags['env-file'])
       }
 
-      // merge parametes and environemtn variables
+      // merge parametes and environment variables
       if (envParams) {
         envParams = envParams.map(e => ({ ...e, init: true }))
         if (paramsAction) {

--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -60,13 +60,20 @@ class ActionGet extends RuntimeBaseCommand {
       } else {
         const saveFile = flags['save-as']
         const saveEnv = flags['save-env']
+        const saveEnvJson = flags['save-env-json']
 
-        if (flags.save || saveFile || saveEnv) {
+        if (flags.save || saveFile || saveEnv || saveEnvJson) {
           // allow env and code to be saved together
           if (saveEnv) {
             const saveEnvFileName = saveEnv
             const envVars = result.parameters.filter(_ => _.init).map(_ => `${_.key}=${_.value}`)
             fs.writeFileSync(saveEnvFileName, envVars.join('\n'))
+          }
+          if (saveEnvJson) {
+            const saveEnvFileName = saveEnvJson
+            const envVars = {}
+            result.parameters.filter(_ => _.init).map(_ => { envVars[_.key] = _.value })
+            fs.writeFileSync(saveEnvFileName, JSON.stringify(envVars, null, 2))
           }
           if (result.exec.binary) {
             const saveFileName = saveFile || `${result.name}.zip`
@@ -126,6 +133,10 @@ ActionGet.flags = {
   'save-env': flags.string({
     char: 'E',
     description: 'save environment variables to FILE as key-value pairs'
+  }),
+  'save-env-json': flags.string({
+    char: 'J',
+    description: 'save environment variables to FILE as JSON'
   }),
   save: flags.boolean({
     description: 'save action code to file corresponding with action name'

--- a/test/commands/runtime/action/get.test.js
+++ b/test/commands/runtime/action/get.test.js
@@ -317,5 +317,16 @@ describe('instance methods', () => {
           expect(fs.writeFileSync).toHaveBeenCalledWith('filename.env', 'ENV_1=true')
         })
     })
+
+    test('retrieve an action --save-env-json', () => {
+      const cmd = rtLib.mockResolvedFixture(rtAction, 'action/get-env.json')
+      fs.writeFileSync = jest.fn()
+      command.argv = ['hello', '--save-env-json', 'filename.json']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith('hello')
+          expect(fs.writeFileSync).toHaveBeenCalledWith('filename.json', JSON.stringify({ ENV_1: true }, null, 2))
+        })
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Write out action env vars to a JSON file which can be edited and re-attached to the action.
Also allow --env and --env-file to be used at the same time (similar to --parms) with --env taking precedence.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
